### PR TITLE
jira doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Replace `<GITHUB_TOKEN>`, `<OPENAI_TOKEN>`, `<OWNER>`, `<REPO>`, and `<PR_NUMBER
 ### Description Command
 
 The usage for the `description` command is similar to the `review` command. Replace `review` with `description` in the command above and execute.
-
+Only difference is that `description` command has extra option `--jira-url` which is used to generate Jira links in the description.
 
 ## GitHub Action
 

--- a/cmd/description/main.go
+++ b/cmd/description/main.go
@@ -23,7 +23,7 @@ var opts struct {
 	Repo        string `long:"repo" env:"REPO" description:"GitHub repo" required:"true"`
 	PRNumber    int    `long:"pr-number" env:"PR_NUMBER" description:"Pull request number" required:"true"`
 	Test        bool   `long:"test" env:"TEST" description:"Test mode"`
-	JiraURL     string `long:"jira-url" env:"JIRA_URL" description:"Jira URL"`
+	JiraURL     string `long:"jira-url" env:"JIRA_URL" description:"Jira URL. Example: https://jira.atlassian.com"`
 }
 
 func main() {


### PR DESCRIPTION
Added support for generating Jira links in the pull request description using the `--jira-url` option in the `description` command. Jira links are generated with the format `[[Jira Ticket|Jira URL/Jira Ticket]]`. Example usage: `pr-helper description --jira-url https://jira.atlassian.com`.