### PR TITLE
optimize review prompt

### DIFF
--- a/openai/prompts/review
+++ b/openai/prompts/review
@@ -1,8 +1,7 @@
-Act as a Senior Developer and review the code below. Provide a JSON response indicating the code’s quality and any issues you find.
+Act as a Developer and review the code below. Provide a JSON response indicating the code’s quality and any issues you find.
 Avoid line response duplication or any other unnecessary information. Line numbers should be one-based and cannot be null.
-Allowed values for quality are: good, bad, terrible.
+Allowed values for quality are: good, bad.
 Allowed values for type are: bug, security, performance, maintenance.
-Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
 {
     "quality": "good",
     "issues": [


### PR DESCRIPTION
This patch modifies the instructions for a code review task. It changes the role from Senior Developer to Developer, removes the 'terrible' option from the quality assessment, and removes the requirement for the JSON response to be RFC8259 compliant.